### PR TITLE
feat(members): add member removal for community/group owners (#87)

### DIFF
--- a/apps/backend/src/communities/communities.controller.ts
+++ b/apps/backend/src/communities/communities.controller.ts
@@ -97,4 +97,15 @@ export class CommunitiesController {
   async getMembers(@CurrentUser() user, @Param('id') id: string) {
     return this.communitiesService.getMembers(id, user.id);
   }
+
+  @Delete(':id/members/:memberId')
+  @UseGuards(OwnershipGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeMember(
+    @CurrentUser() user,
+    @Param('id') id: string,
+    @Param('memberId') memberId: string,
+  ) {
+    await this.membershipService.removeMember(user.id, id, memberId);
+  }
 }

--- a/apps/backend/src/groups/groups.controller.ts
+++ b/apps/backend/src/groups/groups.controller.ts
@@ -106,4 +106,15 @@ export class GroupsController {
   async getMembers(@CurrentUser() user, @Param('id') id: string) {
     return this.groupsService.getMembers(id, user.id);
   }
+
+  @Delete(':id/members/:memberId')
+  @UseGuards(OwnershipGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeMember(
+    @CurrentUser() user,
+    @Param('id') id: string,
+    @Param('memberId') memberId: string,
+  ) {
+    await this.membershipService.removeMember(user.id, id, memberId);
+  }
 }

--- a/apps/frontend/messages/de.json
+++ b/apps/frontend/messages/de.json
@@ -141,7 +141,11 @@
       "alreadyMember": "Du bist bereits Mitglied dieser Gemeinschaft."
     },
     "joinedAnnouncement": "Gemeinschaft {name} wurde zu deiner Liste hinzugefügt",
-    "refreshFailed": "Liste konnte nicht aktualisiert werden. Bitte Seite neu laden."
+    "refreshFailed": "Liste konnte nicht aktualisiert werden. Bitte Seite neu laden.",
+    "removeMember": "Entfernen",
+    "removeMemberConfirm": "Mitglied entfernen?",
+    "removeMemberWarning": "\"{name}\" wird aus der Gemeinschaft und allen Gruppen entfernt.",
+    "memberRemoved": "Mitglied entfernt"
   },
   "groups": {
     "title": "Gruppen",
@@ -199,7 +203,11 @@
       "invalidToken": "Ungültiger Token. Bitte überprüfe die Eingabe.",
       "tokenNotFound": "Ungültiger Einladungslink. Link ist abgelaufen oder ungültig.",
       "alreadyMember": "Du bist bereits Mitglied dieser Gruppe."
-    }
+    },
+    "removeMember": "Entfernen",
+    "removeMemberConfirm": "Mitglied entfernen?",
+    "removeMemberWarning": "\"{name}\" wird aus der Gruppe entfernt.",
+    "memberRemoved": "Mitglied entfernt"
   },
   "listings": {
     "title": "Anzeigen",
@@ -246,7 +254,8 @@
     "uploadImages": "Bilder hochladen (max. 3)",
     "imageLimit": "Maximal 3 Bilder, je 10 MB",
     "sharedWith": "Geteilt mit",
-    "selectCommunities": "Gemeinschaften auswählen",
+    "shareWith": "Teilen mit",
+    "selectCommunities": "Wähle, wer deine Anzeige sehen kann.",
     "selectGroups": "Gruppen auswählen",
     "contact": "Kontaktieren",
     "contactVia": "Kontaktieren via",
@@ -257,7 +266,7 @@
     "address": "Adresse",
     "phone": "Telefon",
     "createdAt": "Erstellt",
-    "edit": "Bearbeiten",
+    "edit": "Anzeige bearbeiten",
     "delete": "Löschen",
     "deleteConfirm": "Sind Sie sicher, dass Sie diese Anzeige löschen möchten?",
     "deleteImage": "Bild löschen",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -141,7 +141,11 @@
       "alreadyMember": "Vous êtes déjà membre de cette communauté."
     },
     "joinedAnnouncement": "La communauté {name} a été ajoutée à votre liste",
-    "refreshFailed": "Impossible de mettre à jour la liste. Veuillez recharger la page."
+    "refreshFailed": "Impossible de mettre à jour la liste. Veuillez recharger la page.",
+    "removeMember": "Supprimer",
+    "removeMemberConfirm": "Supprimer le membre?",
+    "removeMemberWarning": "\"{name}\" sera retiré de la communauté et de tous les groupes.",
+    "memberRemoved": "Membre supprimé"
   },
   "groups": {
     "title": "Groupes",
@@ -199,7 +203,11 @@
       "invalidToken": "Token invalide. Veuillez vérifier la saisie.",
       "tokenNotFound": "Lien d'invitation invalide. Le lien a expiré ou est invalide.",
       "alreadyMember": "Vous êtes déjà membre de ce groupe."
-    }
+    },
+    "removeMember": "Supprimer",
+    "removeMemberConfirm": "Supprimer le membre?",
+    "removeMemberWarning": "\"{name}\" sera retiré du groupe.",
+    "memberRemoved": "Membre supprimé"
   },
   "listings": {
     "title": "Annonces",
@@ -246,7 +254,8 @@
     "uploadImages": "Télécharger des images (max. 3)",
     "imageLimit": "Maximum 3 images de 10 Mo chacune",
     "sharedWith": "Partagé avec",
-    "selectCommunities": "Sélectionner des communautés",
+    "shareWith": "Partager avec",
+    "selectCommunities": "Choisis qui peut voir ton annonce.",
     "selectGroups": "Sélectionner des groupes",
     "contact": "Contacter",
     "contactVia": "Contacter via",
@@ -257,7 +266,7 @@
     "address": "Adresse",
     "phone": "Téléphone",
     "createdAt": "Créé",
-    "edit": "Modifier",
+    "edit": "Modifier l'annonce",
     "delete": "Supprimer",
     "deleteConfirm": "Êtes-vous sûr de vouloir supprimer cette annonce?",
     "deleteImage": "Supprimer l'image",

--- a/apps/frontend/src/components/listings/listing-form.tsx
+++ b/apps/frontend/src/components/listings/listing-form.tsx
@@ -295,7 +295,7 @@ export function ListingForm({ listing, onSubmit }: ListingFormProps) {
       <Card>
         <CardContent className="pt-6 space-y-4">
           <div>
-            <Label className="text-base font-semibold">{t('listings.sharedWith')}</Label>
+            <Label className="text-base font-semibold">{t('listings.shareWith')}</Label>
             <p className="text-sm text-muted-foreground mt-1">
               {t('listings.selectCommunities')}
             </p>


### PR DESCRIPTION
## Summary
- Community/Group Owner kann jetzt Mitglieder entfernen
- X-Button erscheint bei Hover über Nicht-Owner-Mitglieder
- Bestätigungsdialog vor Entfernung
- Entfernung aus Community entfernt auch aus allen Gruppen
- Listings des entfernten Mitglieds werden verborgen

## Changes
- `DELETE /communities/:id/members/:memberId` Endpoint
- `DELETE /groups/:id/members/:memberId` Endpoint
- `removeMember()` in MembershipService + GroupMembershipService
- UI mit X-Button + AlertDialog
- i18n (de/fr)

## Test plan
- [ ] Als Owner Community öffnen → Hover über Mitglied → X-Button sichtbar
- [ ] X klicken → Bestätigungsdialog erscheint
- [ ] Entfernen → Mitglied aus Liste verschwunden
- [ ] Gleicher Flow für Gruppen
- [ ] Als Nicht-Owner: Kein X-Button sichtbar
- [ ] Owner-Eintrag: Kein X-Button

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)