### PR TITLE
style(auth): simplify invite hint to plain text on login page

### DIFF
--- a/apps/frontend/messages/de.json
+++ b/apps/frontend/messages/de.json
@@ -108,6 +108,8 @@
     "linkRefreshed": "Neuer Einladungslink erstellt",
     "invitePendingCommunity": "Einladung zur Community {name}",
     "invitePendingGroup": "Einladung zur Gruppe {name}",
+    "invitePendingCommunityText": "Einladung zur Community",
+    "invitePendingGroupText": "Einladung zur Gruppe",
     "invitePendingText": "Melde dich an, um beizutreten.",
     "join": "Beitreten",
     "leave": "Verlassen",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -108,6 +108,8 @@
     "linkRefreshed": "Nouveau lien d'invitation créé",
     "invitePendingCommunity": "Invitation à la communauté {name}",
     "invitePendingGroup": "Invitation au groupe {name}",
+    "invitePendingCommunityText": "Invitation à la communauté",
+    "invitePendingGroupText": "Invitation au groupe",
     "invitePendingText": "Connecte-toi pour rejoindre.",
     "join": "Rejoindre",
     "leave": "Quitter",

--- a/apps/frontend/src/components/auth/login-page.tsx
+++ b/apps/frontend/src/components/auth/login-page.tsx
@@ -8,7 +8,6 @@ import { Label } from '@/components/ui/label';
 import { useState, useEffect } from 'react';
 import { Link } from '@/navigation';
 import { useToast } from '@/hooks/use-toast';
-import { Mail } from 'lucide-react';
 import { HowItWorks } from '@/components/how-it-works';
 import Image from 'next/image';
 
@@ -97,20 +96,13 @@ export function LoginPage() {
         <Card className="w-full max-w-md bg-white/90 dark:bg-gray-900/90 backdrop-blur-xl shadow-2xl border border-white/20">
           <CardContent className="space-y-4 p-6 lg:p-8 pt-6">
             {hasPendingInvite && (
-              <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-4">
-                <div className="flex items-start gap-3">
-                  <Mail className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5 flex-shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <p className="font-semibold text-blue-900 dark:text-blue-100 text-sm">
-                      {t(inviteType === 'group' ? 'communities.invitePendingGroup' : 'communities.invitePendingCommunity', { name: inviteName || '' })}
-                    </p>
-                    <p className="text-blue-700 dark:text-blue-300 text-xs mt-1">
-                      {t('communities.invitePendingText')}
-                    </p>
-                  </div>
-                </div>
+              <div className="text-sm leading-relaxed text-center">
+                <p>{t(inviteType === 'group' ? 'communities.invitePendingGroupText' : 'communities.invitePendingCommunityText')}</p>
+                <p className="font-semibold">{inviteName}</p>
+                <p>{t('communities.invitePendingText')}</p>
               </div>
             )}
+
             <Button
               className="w-full"
               size="lg"
@@ -160,7 +152,7 @@ export function LoginPage() {
                 onCheckedChange={(checked) => setAcceptedTerms(!!checked)}
                 className="mt-1"
               />
-              <Label htmlFor="terms" className="text-sm leading-relaxed cursor-pointer">
+              <Label htmlFor="terms" className="text-sm font-normal leading-relaxed cursor-pointer">
                 {t('auth.acceptTerms')}{' '}
                 <Link href="/terms" className="underline hover:text-primary">
                   {t('auth.termsOfService')}


### PR DESCRIPTION
## Summary
- Move invite notification from styled box to simple centered text above login buttons
- Show structured format: "Einladung zur Gruppe/Community" + bold name + "Melde dich an..."
- Add new i18n keys for separate group/community text
- Normalize font-weight on terms checkbox label

## Test plan
- [ ] Open invite link as unauthenticated user
- [ ] Verify invite hint appears above login buttons as plain centered text
- [ ] Verify group name is bold
- [ ] Verify terms text has same font weight as invite text

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)