### PR TITLE
feat(mobile-filter): show dynamic listing count in filter button

### DIFF
--- a/apps/frontend/messages/de.json
+++ b/apps/frontend/messages/de.json
@@ -303,6 +303,7 @@
     "openFilters": "Filter öffnen",
     "filterActive": "Filter aktiv",
     "filterDescription": "Filtern Sie Inserate nach Typ, Kategorie und Suchbegriff",
+    "showResults": "{count} Inserate anzeigen",
     "yourListing": "Ihr Inserat",
     "yourListingDescription": "Dies ist Ihr Inserat. Andere Benutzer sehen hier Ihre Kontaktinformationen.",
     "visibleToOthers": "Für andere sichtbar",

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -303,6 +303,7 @@
     "openFilters": "Ouvrir les filtres",
     "filterActive": "Filtre actif",
     "filterDescription": "Filtrez les annonces par type, catégorie et terme de recherche",
+    "showResults": "Afficher {count} annonces",
     "yourListing": "Votre annonce",
     "yourListingDescription": "Ceci est votre annonce. Les autres utilisateurs verront vos coordonnées ici.",
     "visibleToOthers": "Visible par les autres",


### PR DESCRIPTION
## Summary
- Mobile Filter Modal zeigt jetzt die Anzahl der Inserate im Button an
- Debounced API-Call (300ms) bei Filteränderungen
- Skeleton-Animation während Laden
- Button bleibt auch bei 0 Ergebnissen klickbar

Closes #124

## Changes
| File | Change |
|------|--------|
| `mobile-filter-sheet.tsx` | Preview count state, debounced API call, dynamic button text |
| `de.json` | Added `listings.showResults` translation |
| `fr.json` | Added `listings.showResults` translation |

## Test plan
- [ ] Open mobile filter modal → Button shows "{count} Inserate anzeigen"
- [ ] Change filter (e.g. category) → Count updates after ~300ms
- [ ] Set filters to get 0 results → Button shows "0 Inserate anzeigen" and remains clickable
- [ ] Click button → Modal closes, filtered listings displayed
- [ ] Switch to French → Button shows "Afficher {count} annonces"

🤖 Generated with [Claude Code](https://claude.ai/code)