### PR TITLE
fix(auth): Auto-detect production environment for cookie settings

### DIFF
--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -27,8 +27,9 @@ export class AuthController {
   private getCookieOptions(
     type: 'access' | 'refresh' | 'pending',
   ): CookieOptions {
-    const isProduction = process.env.NODE_ENV === 'production';
     const cookieDomain = process.env.COOKIE_DOMAIN;
+    // Auto-detect: COOKIE_DOMAIN is only set in deployed environments (Railway)
+    const isProduction = process.env.NODE_ENV === 'production' || !!cookieDomain;
 
     const baseOptions: CookieOptions = {
       httpOnly: true,

--- a/apps/frontend/src/app/[locale]/auth/callback/page.tsx
+++ b/apps/frontend/src/app/[locale]/auth/callback/page.tsx
@@ -31,7 +31,7 @@ function AuthCallbackContent() {
       const redirectTo = searchParams.get('redirectTo');
 
       if (redirectTo && isValidRedirectUrl(redirectTo)) {
-        router.push(redirectTo);
+        router.replace(redirectTo);
         return;
       }
 
@@ -41,16 +41,16 @@ function AuthCallbackContent() {
 
       if (communityToken) {
         sessionStorage.removeItem('pendingInviteToken');
-        router.push(`/communities/join?token=${communityToken}`);
+        router.replace(`/communities/join?token=${communityToken}`);
       } else if (groupToken) {
         sessionStorage.removeItem('pendingGroupInviteToken');
-        router.push(`/groups/join?token=${groupToken}`);
+        router.replace(`/groups/join?token=${groupToken}`);
       } else {
-        router.push('/');
+        router.replace('/');
       }
     }).catch(() => {
       // Auth failed, redirect to home
-      router.push('/');
+      router.replace('/');
     });
   }, [searchParams, router, fetchUser]);
 


### PR DESCRIPTION
## Summary
- Auto-detect production using `COOKIE_DOMAIN` presence (Railway sets this but not `NODE_ENV`)
- Change `router.push()` to `router.replace()` in auth callback to prevent browser history warning

## Changes
| File | Change |
|------|--------|
| `apps/backend/src/auth/auth.controller.ts` | Production detection: `NODE_ENV === 'production' \|\| !!cookieDomain` |
| `apps/frontend/src/app/[locale]/auth/callback/page.tsx` | All `router.push()` → `router.replace()` |

## Test plan
- [ ] Local OAuth login works without needing page refresh
- [ ] No "Session History Item Has Been Marked Skippable" console warning
- [ ] Browser back button skips `/auth/callback` page
- [ ] Cookies have correct settings (local: `sameSite=Lax`, deployed: `sameSite=None`)

Fixes #149

🤖 Generated with [Claude Code](https://claude.ai/code)