### PR TITLE
fix(listings): clear priceTimeUnit when type is not RENT

### DIFF
--- a/apps/backend/src/listings/listings.service.ts
+++ b/apps/backend/src/listings/listings.service.ts
@@ -4,6 +4,7 @@ import { CreateListingDto, UpdateListingDto, FilterListingsDto } from './dto';
 import { VisibilityService } from './visibility.service';
 import { ImageService } from './image.service';
 import { PaginatedResponse } from '../common/types';
+import { ListingType } from '@prisma/client';
 
 @Injectable()
 export class ListingsService {
@@ -21,7 +22,7 @@ export class ListingsService {
         description: dto.description,
         type: dto.type,
         price: dto.price,
-        priceTimeUnit: dto.priceTimeUnit,
+        priceTimeUnit: dto.type === ListingType.RENT ? dto.priceTimeUnit : null,
         category: dto.category,
       },
       include: {
@@ -376,6 +377,9 @@ export class ListingsService {
       throw new ForbiddenException('You can only update your own listings');
     }
 
+    // Determine effective type: use dto.type if provided, otherwise keep existing
+    const effectiveType = dto.type ?? listing.type;
+
     const updated = await this.prisma.listing.update({
       where: { id },
       data: {
@@ -383,7 +387,8 @@ export class ListingsService {
         description: dto.description,
         type: dto.type,
         price: dto.price,
-        priceTimeUnit: dto.priceTimeUnit,
+        priceTimeUnit:
+          effectiveType === ListingType.RENT ? dto.priceTimeUnit : null,
         category: dto.category,
       },
       include: {


### PR DESCRIPTION
## Summary

- Fixes bug where `priceTimeUnit` persisted in database when listing type changed from RENT to SELL/LEND/SEARCH
- Backend now explicitly sets `priceTimeUnit` to `null` for non-RENT types in both `create()` and `update()` methods
- Ensures data integrity regardless of frontend behavior

## Changes

- `apps/backend/src/listings/listings.service.ts`:
  - Added `ListingType` import from `@prisma/client`
  - `create()`: Only set `priceTimeUnit` if type is RENT
  - `update()`: Compute effective type and clear `priceTimeUnit` for non-RENT types

## Test Plan

- [x] Create RENT listing with priceTimeUnit → change to SELL → priceTimeUnit cleared
- [x] Create RENT listing with priceTimeUnit → change to LEND → priceTimeUnit cleared
- [x] Create new SELL listing → no priceTimeUnit stored
- [x] Edit RENT listing without changing type → priceTimeUnit preserved
- [x] Backend build passes
- [x] Frontend type-check passes

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)