### PR TITLE
feat(listings): Image Lazy Loading & Optimization

### DIFF
--- a/apps/frontend/src/components/listings/listing-card.tsx
+++ b/apps/frontend/src/components/listings/listing-card.tsx
@@ -14,10 +14,11 @@ import Image from 'next/image';
 
 interface ListingCardProps {
   listing: Listing;
+  priority?: boolean;
   onBookmarkChange?: (listingId: string, isBookmarked: boolean) => void;
 }
 
-export function ListingCard({ listing, onBookmarkChange }: ListingCardProps) {
+export function ListingCard({ listing, priority, onBookmarkChange }: ListingCardProps) {
   const t = useTranslations();
   const locale = useLocale();
   const { user } = useAuth();
@@ -64,6 +65,7 @@ export function ListingCard({ listing, onBookmarkChange }: ListingCardProps) {
               alt={listing.title}
               fill
               className="object-cover"
+              priority={priority}
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center text-muted-foreground">

--- a/apps/frontend/src/components/listings/listings-page.tsx
+++ b/apps/frontend/src/components/listings/listings-page.tsx
@@ -184,8 +184,12 @@ function ListingsPageContent() {
             </div>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {listings.map((listing) => (
-                <ListingCard key={listing.id} listing={listing} />
+              {listings.map((listing, index) => (
+                <ListingCard
+                  key={listing.id}
+                  listing={listing}
+                  priority={index < 9}
+                />
               ))}
             </div>
           )}


### PR DESCRIPTION
## Summary
- Add `priority` prop to `ListingCard` for LCP optimization
- First 9 images load with priority (covers 3 rows on desktop)
- Remaining images use Next.js native lazy loading
- Improves initial page load performance and reduces network traffic

## Changes
- `listing-card.tsx`: Added optional `priority` prop, passed to Next.js Image
- `listings-page.tsx`: Pass `priority={index < 9}` to first 9 cards

## Test Plan
- [x] Verify first 9 images load immediately (Network tab)
- [x] Verify remaining images lazy load on scroll
- [x] TypeScript compiles without errors
- [x] Frontend build succeeds

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)